### PR TITLE
Fix Maestro iOS tests

### DIFF
--- a/.github/workflows/lightsaber-ci.yml
+++ b/.github/workflows/lightsaber-ci.yml
@@ -19,8 +19,7 @@ jobs:
       - uses: ./.github/actions/setup-lightsaber-ci
 
       - name: Build Shared
-        # TODO Understand why compileIosMainKotlinMetadata fails every time
-        run: ./gradlew shared:assemble -x compileIosMainKotlinMetadata
+        run: ./gradlew shared:assemble
 
   build-androidApp:
     runs-on: macos-14
@@ -73,6 +72,13 @@ jobs:
           # apply provisioning profile
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
+      # Generate dummy framework to ensure that compose-resources are copied.
+      # See https://github.com/JetBrains/compose-multiplatform/issues/5011
+      - name: Generate dummy framework
+        run: |
+          mkdir -p ./shared/build/compose/cocoapods/compose-resources
+          ./gradlew generateDummyFramework
 
       - name: Shared Pod Install
         run: ./gradlew podInstall
@@ -189,3 +195,14 @@ jobs:
         run: |
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=60000
           maestro test .maestro
+
+      - name: Collect logs
+        if: failure()
+        run: xcrun simctl spawn "${{ steps.ios-simulator.outputs.udid }}" log collect --output ${{ github.workspace }}/${{ steps.ios-simulator.outputs.udid }}.logarchive
+
+      - name: Archive the device logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: device-logs
+          path: ${{ github.workspace }}/*.logarchive

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-appcompat = "1.7.0"
 androidx-core-ktx = "1.13.1"
 datastore-version = "1.1.1"
 compose-ui-test = "1.6.7"
+kermit = "2.0.4"
 
 [libraries]
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
@@ -26,6 +27,7 @@ androidx-datastore-core-okio = { group = "androidx.datastore", name = "datastore
 androidx-datastore-preferences-core = { group = "androidx.datastore", name = "datastore-preferences-core", version.ref = "datastore-version" }
 androidx-compose-ui-test-junit4-android = { group = "androidx.compose.ui" , name = "ui-test-junit4-android", version.ref = "compose-ui-test" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui" , name = "ui-test-manifest", version.ref = "compose-ui-test" }
+kermit = { group = "co.touchlab" , name = "kermit", version.ref = "kermit" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -16,6 +16,3 @@ struct ContentView: View {
                 .ignoresSafeArea(.all, edges: .bottom) // Compose has own keyboard handler
     }
 }
-
-
-

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
                 implementation(libs.circuitx.gesture.navigation)
                 implementation(libs.androidx.datastore.preferences.core)
                 implementation(libs.androidx.datastore.core.okio)
+                api(libs.kermit)
             }
         }
         commonTest {


### PR DESCRIPTION
These changes represent a collection of debugging focused steps to fix the runtime crash that occurred in the Maestro iOS tests after updating the project to Kotlin 2.0

Ultimately, the issue ended up being a chicken-or-egg issue related to compose resources not being installed into the final iOS app.