### PR TITLE
Adopt Anvil Kotlin Inject

### DIFF
--- a/.github/actions/setup-maestro/action.yml
+++ b/.github/actions/setup-maestro/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Install Maestro 
-      run: export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
+      run: export MAESTRO_VERSION=1.39.0; curl -Ls "https://get.maestro.mobile.dev" | bash
       shell: bash
       
     - name: Add maestro to PATH 

--- a/.github/workflows/lightsaber-ci.yml
+++ b/.github/workflows/lightsaber-ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: ./.github/actions/setup-lightsaber-ci
 
       - name: Build Shared
-        run: ./gradlew shared:assemble
+        run: ./gradlew shared:assemble -x compileIosMainKotlinMetadata
 
   build-androidApp:
     runs-on: macos-14
@@ -116,15 +116,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-lightsaber-ci
-      - uses: futureware-tech/simulator-action@v3
+      - uses: futureware-tech/simulator-action@v4
         id: ios-simulator
         with:
           model: 'iPhone 15'
           os: iOS
           os_version: 17.0
-
-      - name: Wait for the simulator to be ready
-        run: xcrun simctl bootstatus "${{ steps.ios-simulator.outputs.udid }}" -b
+          wait_for_boot: true
+          shutdown_after_job: false
 
       - name: iOS UI Tests
         run: ./gradlew :shared:iosSimulatorArm64Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,26 @@
 [versions]
 core-splashscreen = "1.0.1"
-kotlin = "2.0.10"
-agp = "8.2.2"
+kotlin = "2.0.21"
+agp = "8.5.2"
 compose = "1.6.11"
-ksp = "2.0.0-1.0.22"
+ksp = "2.0.21-1.0.25"
 kotlin-inject = "0.7.2"
-circuit = "0.23.1"
-androidx-activity-compose = "1.9.2"
+circuit = "0.25.0"
+androidx-activity-compose = "1.9.3"
 androidx-appcompat = "1.7.0"
 androidx-core-ktx = "1.13.1"
 datastore-version = "1.1.1"
-compose-ui-test = "1.7.1"
+compose-ui-test = "1.7.4"
 kermit = "2.0.4"
+anvil-kotlin-inject = "0.0.5"
 
 [libraries]
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
 kotlin-inject-runtime-kmp = { module = "me.tatarka.inject:kotlin-inject-runtime-kmp", version.ref = "kotlin-inject" }
 kotlin-inject-ksp = { module = "me.tatarka.inject:kotlin-inject-compiler-ksp", version.ref = "kotlin-inject" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+circuit-codegen = { module = "com.slack.circuit:circuit-codegen", version.ref = "circuit" }
+circuit-codegen-annotations = { module = "com.slack.circuit:circuit-codegen-annotations", version.ref = "circuit" }
 circuit-foundation = { module = "com.slack.circuit:circuit-foundation", version.ref = "circuit" }
 circuitx-gesture-navigation = { module = "com.slack.circuit:circuitx-gesture-navigation", version.ref = "circuit" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity-compose" }
@@ -28,6 +31,9 @@ androidx-datastore-preferences-core = { group = "androidx.datastore", name = "da
 androidx-compose-ui-test-junit4-android = { group = "androidx.compose.ui" , name = "ui-test-junit4-android", version.ref = "compose-ui-test" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui" , name = "ui-test-manifest", version.ref = "compose-ui-test" }
 kermit = { group = "co.touchlab" , name = "kermit", version.ref = "kermit" }
+anvil-kotlin-inject-compiler = { group = "software.amazon.lastmile.kotlin.inject.anvil" , name = "compiler", version.ref = "anvil-kotlin-inject" }
+anvil-kotlin-inject-runtime = { group = "software.amazon.lastmile.kotlin.inject.anvil" , name = "runtime", version.ref = "anvil-kotlin-inject" }
+anvil-kotlin-inject-runtime-optional = { group = "software.amazon.lastmile.kotlin.inject.anvil" , name = "runtime-optional", version.ref = "anvil-kotlin-inject" }
 
 [plugins]
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Aug 30 21:10:07 CDT 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.google.devtools.ksp.gradle.KspTaskMetadata
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
@@ -10,6 +9,12 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.plugin.parcelize)
     alias(libs.plugins.kotlin.native.cocoapods)
+}
+
+ksp {
+    arg("circuit.codegen.lenient", "true")
+    arg("circuit.codegen.mode", "kotlin_inject_anvil")
+    arg("kotlin-inject-anvil-contributing-annotations", "com.slack.circuit.codegen.annotations.CircuitInject")
 }
 
 kotlin {
@@ -51,11 +56,14 @@ kotlin {
                 @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
                 implementation(compose.components.resources)
                 implementation(libs.kotlin.inject.runtime.kmp)
+                api(libs.circuit.codegen.annotations)
                 implementation(libs.circuit.foundation)
                 implementation(libs.circuitx.gesture.navigation)
                 implementation(libs.androidx.datastore.preferences.core)
                 implementation(libs.androidx.datastore.core.okio)
                 api(libs.kermit)
+                implementation(libs.anvil.kotlin.inject.runtime)
+                implementation(libs.anvil.kotlin.inject.runtime.optional)
             }
         }
         commonTest {
@@ -103,8 +111,22 @@ android {
  */
 dependencies {
     add("kspCommonMainMetadata", libs.kotlin.inject.ksp)
+    add("kspCommonMainMetadata", libs.anvil.kotlin.inject.compiler)
+    add("kspCommonMainMetadata", libs.circuit.codegen)
+
     add("kspAndroid", libs.kotlin.inject.ksp)
+    add("kspAndroid", libs.anvil.kotlin.inject.compiler)
+    add("kspAndroid", libs.circuit.codegen)
+
     add("kspIosX64", libs.kotlin.inject.ksp)
+    add("kspIosX64", libs.anvil.kotlin.inject.compiler)
+    add("kspIosX64", libs.circuit.codegen)
+
     add("kspIosArm64", libs.kotlin.inject.ksp)
+    add("kspIosArm64", libs.anvil.kotlin.inject.compiler)
+    add("kspIosArm64", libs.circuit.codegen)
+
     add("kspIosSimulatorArm64", libs.kotlin.inject.ksp)
+    add("kspIosSimulatorArm64", libs.anvil.kotlin.inject.compiler)
+    add("kspIosSimulatorArm64", libs.circuit.codegen)
 }

--- a/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/audio/AndroidSoundPlayer.kt
+++ b/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/audio/AndroidSoundPlayer.kt
@@ -7,9 +7,14 @@ import android.media.SoundPool.OnLoadCompleteListener
 import xyz.alaniz.aaron.lightsaber.di.AppContext
 import kotlinx.coroutines.suspendCancellableCoroutine
 import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import kotlin.coroutines.resume
 
 @Inject
+@ContributesBinding(AppScope::class)
+@SingleIn(AppScope::class)
 class AndroidSoundPlayer(
     appContext: AppContext,
     private val context: Context = appContext.value,

--- a/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/di/AndroidMotionComponent.kt
+++ b/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/di/AndroidMotionComponent.kt
@@ -3,28 +3,26 @@ package xyz.alaniz.aaron.lightsaber.di
 import android.content.Context
 import android.hardware.Sensor
 import android.hardware.SensorManager
-import kotlinx.coroutines.flow.Flow
-import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import xyz.alaniz.aaron.lightsaber.motion.Accelerometer
-import xyz.alaniz.aaron.lightsaber.motion.AndroidSwingDetector
-import xyz.alaniz.aaron.lightsaber.motion.SwingEvent
 
-@Component
-abstract class AndroidMotionComponent(@get:Provides internal val appContext: AppContext) {
+@ContributesTo(AppScope::class)
+interface AndroidMotionComponent {
     @Provides
-    internal fun providesSensorManager(appContext: AppContext): SensorManager =
+    @SingleIn(AppScope::class)
+    fun providesSensorManager(appContext: AppContext): SensorManager =
         appContext.value.getSystemService(Context.SENSOR_SERVICE) as SensorManager
 
     @Provides
-    internal fun providesAccelerometer(sensorManager: SensorManager): Accelerometer = Accelerometer(
+    @SingleIn(AppScope::class)
+    fun providesAccelerometer(sensorManager: SensorManager): Accelerometer = Accelerometer(
         sensor = requireNotNull(
             sensorManager.getDefaultSensor(
                 Sensor.TYPE_ACCELEROMETER
             )
         )
     )
-
-    internal val AndroidSwingDetector.bind: Flow<SwingEvent>
-        @Provides get() = this.swings
 }

--- a/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/di/AndroidSoundComponent.kt
+++ b/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/di/AndroidSoundComponent.kt
@@ -2,17 +2,13 @@ package xyz.alaniz.aaron.lightsaber.di
 
 import android.content.Context.AUDIO_SERVICE
 import android.media.AudioManager
-import xyz.alaniz.aaron.lightsaber.audio.AndroidSoundPlayer
-import xyz.alaniz.aaron.lightsaber.audio.SoundPlayer
-import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
-@Component
-abstract class AndroidSoundComponent(@get:Provides internal val appContext: AppContext) {
+@ContributesTo(AppScope::class)
+interface AndroidSoundComponent {
     @Provides
-    internal fun providesAudioManager(appContext: AppContext): AudioManager =
+    fun providesAudioManager(appContext: AppContext): AudioManager =
         appContext.value.getSystemService(AUDIO_SERVICE) as AudioManager
-
-    internal val AndroidSoundPlayer.bind: SoundPlayer
-        @Provides get() = this
 }

--- a/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/main.android.kt
+++ b/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/main.android.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import xyz.alaniz.aaron.lightsaber.di.AndroidApplicationComponent
 import xyz.alaniz.aaron.lightsaber.di.AppContext
+import xyz.alaniz.aaron.lightsaber.di.DataStorePath
 import xyz.alaniz.aaron.lightsaber.di.create
 import xyz.alaniz.aaron.lightsaber.di.dataStoreFileName
 import xyz.alaniz.aaron.lightsaber.ui.lightsaber.AndroidLightsaberScreen
@@ -11,11 +12,10 @@ import xyz.alaniz.aaron.lightsaber.ui.lightsaber.AndroidLightsaberScreen
 @Composable
 fun MainView(appContext: Context) {
     val dataStorePath = appContext.filesDir.resolve(dataStoreFileName).absolutePath
-    App(initialScreen = AndroidLightsaberScreen) { scope, navigator ->
+    App(initialScreen = AndroidLightsaberScreen) { scope ->
         AndroidApplicationComponent::class.create(
-            navigator = navigator,
             appScope = scope,
-            dataStorePath = dataStorePath,
+            dataStorePath = DataStorePath(value = dataStorePath),
             appContext = AppContext(appContext)
         )
     }

--- a/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/motion/AndroidSwingDetector.kt
+++ b/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/motion/AndroidSwingDetector.kt
@@ -9,17 +9,21 @@ import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import me.tatarka.inject.annotations.Inject
-import xyz.alaniz.aaron.lightsaber.motion.SwingEvent
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import kotlin.math.abs
 
 private const val SWING_THRESHOLD = 8
 
 @Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class AndroidSwingDetector(
     private val sensorManager: SensorManager,
     private val accelerometer: Accelerometer
-) {
-    val swings: Flow<SwingEvent>
+) : SwingDetector {
+    override val swings: Flow<SwingEvent>
         get() = callbackFlow {
             val sensorEventListener = object : SensorEventListener {
                 override fun onSensorChanged(event: SensorEvent) {

--- a/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/lightsaber/AndroidLightsaberScreen.kt
+++ b/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/lightsaber/AndroidLightsaberScreen.kt
@@ -3,8 +3,11 @@ package xyz.alaniz.aaron.lightsaber.ui.lightsaber
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
 
 @Inject
 @Parcelize
+@ContributesBinding(scope = AppScope::class, boundType = LightsaberScreen::class)
 data object AndroidLightsaberScreen : LightsaberScreen, Parcelable

--- a/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/AndroidSettingsScreen.kt
+++ b/shared/src/androidMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/AndroidSettingsScreen.kt
@@ -3,7 +3,10 @@ package xyz.alaniz.aaron.lightsaber.ui.settings
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
 @Inject
 @Parcelize
+@ContributesBinding(scope = AppScope::class, boundType = SettingsScreen::class)
 data object AndroidSettingsScreen : SettingsScreen, Parcelable

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/App.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/App.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.CoroutineScope
 import xyz.alaniz.aaron.lightsaber.di.ApplicationComponent
 
 @Composable
-fun App(initialScreen: Screen, createAppComponent: (CoroutineScope, Navigator) -> ApplicationComponent) {
+fun App(initialScreen: Screen, createAppComponent: (CoroutineScope) -> ApplicationComponent) {
     val scope = rememberCoroutineScope()
     val backstack = rememberSaveableBackStack(root = initialScreen)
     val navigator = rememberCircuitNavigator(backstack) {
@@ -22,7 +22,7 @@ fun App(initialScreen: Screen, createAppComponent: (CoroutineScope, Navigator) -
          * TODO handle root pops
          */
     }
-    val appComponent = remember { createAppComponent(scope, navigator) }
+    val appComponent = remember { createAppComponent(scope) }
 
     CircuitCompositionLocals(appComponent.circuit) {
         NavigableCircuitContent(

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/data/SettingsRepository.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/data/SettingsRepository.kt
@@ -11,29 +11,38 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import me.tatarka.inject.annotations.Inject
-import xyz.alaniz.aaron.lightsaber.di.DataScope
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import xyz.alaniz.aaron.lightsaber.ui.common.LightsaberGreen
 
 private val defaultBladeColor = LightsaberGreen.value
 
+interface SettingsRepository {
+    val lightsaberSettings: StateFlow<LightsaberSettings>
+
+    suspend fun saveSettings(lightsaberSettings: LightsaberSettings)
+}
+
 @Inject
-@DataScope
-class SettingsRepository(
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSettingsRepository(
     scope: CoroutineScope,
     private val dataStore: DataStore<Preferences>
-) {
+) : SettingsRepository {
     private val bladeColorKey = longPreferencesKey("lightsaber_blade_color")
 
     private val defaultSettings = LightsaberSettings(
         bladeColor = Color(defaultBladeColor)
     )
 
-    val lightsaberSettings: StateFlow<LightsaberSettings> = dataStore.data.map {
+    override val lightsaberSettings: StateFlow<LightsaberSettings> = dataStore.data.map {
         val bladeColor: ULong = it[bladeColorKey]?.toULong() ?: defaultBladeColor
         LightsaberSettings(bladeColor = Color(bladeColor))
     }.stateIn(scope = scope, started = SharingStarted.Eagerly, initialValue = defaultSettings)
 
-    suspend fun saveSettings(lightsaberSettings: LightsaberSettings) {
+    override suspend fun saveSettings(lightsaberSettings: LightsaberSettings) {
         dataStore.edit {
             it[bladeColorKey] = lightsaberSettings.bladeColor.value.toLong()
         }

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/AppScope.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/AppScope.kt
@@ -1,7 +1,0 @@
-package xyz.alaniz.aaron.lightsaber.di
-
-import me.tatarka.inject.annotations.Scope
-
-@Scope
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
-annotation class AppScope

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/ApplicationComponent.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/ApplicationComponent.kt
@@ -3,33 +3,19 @@ package xyz.alaniz.aaron.lightsaber.di
 import com.slack.circuit.foundation.Circuit
 import com.slack.circuit.runtime.presenter.Presenter
 import com.slack.circuit.runtime.ui.Ui
-import me.tatarka.inject.annotations.IntoSet
 import me.tatarka.inject.annotations.Provides
-import xyz.alaniz.aaron.lightsaber.ui.lightsaber.LightsaberPresenterFactory
-import xyz.alaniz.aaron.lightsaber.ui.lightsaber.LightsaberUiFactory
-import xyz.alaniz.aaron.lightsaber.ui.settings.SettingsPresenterFactory
-import xyz.alaniz.aaron.lightsaber.ui.settings.SettingsUiFactory
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
-@AppScope
-abstract class ApplicationComponent {
-    abstract val circuit: Circuit
-    protected abstract val presenterFactories: Set<Presenter.Factory>
-    protected abstract val uiFactories: Set<Ui.Factory>
-
-    protected val LightsaberPresenterFactory.bind: Presenter.Factory
-        @IntoSet @Provides get() = this
-
-    protected val LightsaberUiFactory.bind: Ui.Factory
-        @IntoSet @Provides get() = this
-
-    protected val SettingsPresenterFactory.bind: Presenter.Factory
-        @IntoSet @Provides get() = this
-
-    protected val SettingsUiFactory.bind: Ui.Factory
-        @IntoSet @Provides get() = this
+@ContributesTo(AppScope::class)
+interface ApplicationComponent {
+    val circuit: Circuit
 
     @Provides
-    protected fun provideCircuit(): Circuit = Circuit.Builder()
+    fun provideCircuit(
+        presenterFactories: Set<Presenter.Factory>,
+        uiFactories: Set<Ui.Factory>
+    ) = Circuit.Builder()
         .addUiFactories(uiFactories)
         .addPresenterFactories(presenterFactories)
         .build()

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/DataScope.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/DataScope.kt
@@ -1,7 +1,0 @@
-package xyz.alaniz.aaron.lightsaber.di
-
-import me.tatarka.inject.annotations.Scope
-
-@Scope
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY_GETTER)
-annotation class DataScope

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/DataStorePath.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/DataStorePath.kt
@@ -1,0 +1,6 @@
+package xyz.alaniz.aaron.lightsaber.di
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+value class DataStorePath(val value: String)

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/DatastoreComponent.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/di/DatastoreComponent.kt
@@ -3,24 +3,19 @@ package xyz.alaniz.aaron.lightsaber.di
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
-import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
 import okio.Path.Companion.toPath
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
 
 const val dataStoreFileName = "lightsaber.preferences_pb"
 
-@Component
-@DataScope
-abstract class DatastoreComponent(
-    @get:Provides internal val scope: CoroutineScope,
-    private val dataStorePath: String) {
+@ContributesTo(AppScope::class)
+interface DatastoreComponent {
     @Provides
-    @DataScope
-    internal fun provideDatastorePreferences(): DataStore<Preferences> {
+    fun provideDatastorePreferences(dataStorePath: DataStorePath): DataStore<Preferences> {
         return PreferenceDataStoreFactory.createWithPath {
-            dataStorePath.toPath()
+            dataStorePath.value.toPath()
         }
     }
-    companion object
 }

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/motion/SwingDetector.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/motion/SwingDetector.kt
@@ -1,0 +1,7 @@
+package xyz.alaniz.aaron.lightsaber.motion
+
+import kotlinx.coroutines.flow.Flow
+
+interface SwingDetector {
+    val swings: Flow<SwingEvent>
+}

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/lightsaber/LightsaberUi.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/lightsaber/LightsaberUi.kt
@@ -39,23 +39,19 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.slack.circuit.runtime.CircuitContext
-import com.slack.circuit.runtime.screen.Screen
-import com.slack.circuit.runtime.ui.Ui
-import com.slack.circuit.runtime.ui.ui
+import com.slack.circuit.codegen.annotations.CircuitInject
 import lightsaber.shared.generated.resources.Res
 import lightsaber.shared.generated.resources.lightsaber_handle
 import lightsaber.shared.generated.resources.lightsaber_screen_lightsaber_blade
 import lightsaber.shared.generated.resources.lightsaber_screen_lightsaber_handle
 import lightsaber.shared.generated.resources.lightsaber_screen_settings_icon
-import me.tatarka.inject.annotations.Inject
-import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import xyz.alaniz.aaron.lightsaber.ui.common.LightsaberTheme
 
 
-@OptIn(ExperimentalResourceApi::class)
+@CircuitInject(LightsaberScreen::class, AppScope::class)
 @Composable
 fun Lightsaber(lightsaberState: LightsaberState, modifier: Modifier = Modifier) {
     LightsaberTheme {
@@ -144,7 +140,6 @@ fun Lightsaber(lightsaberState: LightsaberState, modifier: Modifier = Modifier) 
     }
 }
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 private fun SettingsIcon(modifier: Modifier = Modifier, onSettingsClicked: () -> Unit) {
     IconButton(onClick = {
@@ -157,7 +152,6 @@ private fun SettingsIcon(modifier: Modifier = Modifier, onSettingsClicked: () ->
     }
 }
 
-@OptIn(ExperimentalResourceApi::class)
 @Composable
 private fun LightsaberBlade(
     modifier: Modifier = Modifier,
@@ -209,21 +203,5 @@ private fun LightsaberBlade(
                 }
             }
     ) {
-    }
-}
-
-@Inject
-class LightsaberUiFactory : Ui.Factory {
-    override fun create(screen: Screen, context: CircuitContext): Ui<*>? {
-        return when (screen) {
-            is LightsaberScreen -> ui<LightsaberState> { state, modifier ->
-                Lightsaber(
-                    state,
-                    modifier
-                )
-            }
-
-            else -> null
-        }
     }
 }

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/SettingsPresenter.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/SettingsPresenter.kt
@@ -5,16 +5,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color
-import com.slack.circuit.runtime.CircuitContext
+import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
-import com.slack.circuit.runtime.presenter.presenterOf
-import com.slack.circuit.runtime.screen.Screen
 import kotlinx.coroutines.launch
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import xyz.alaniz.aaron.lightsaber.data.SettingsRepository
 import xyz.alaniz.aaron.lightsaber.ui.common.LightsaberBlue
 import xyz.alaniz.aaron.lightsaber.ui.common.LightsaberGreen
@@ -35,10 +34,11 @@ data class SettingsState(
 ) :
     CircuitUiState
 
+@CircuitInject(SettingsScreen::class, AppScope::class)
 @Inject
 class SettingsPresenter(
     private val settingsRepository: SettingsRepository,
-    private val navigator: Navigator
+    @Assisted private val navigator: Navigator
 ) :
     Presenter<SettingsState> {
 
@@ -65,25 +65,6 @@ class SettingsPresenter(
                     )
                 }
             }
-        }
-    }
-}
-
-@Inject
-class SettingsPresenterFactory(private val settingsPresenter: SettingsPresenter) :
-    Presenter.Factory {
-
-    override fun create(
-        screen: Screen,
-        navigator: Navigator,
-        context: CircuitContext,
-    ): Presenter<*>? {
-        return when (screen) {
-            is SettingsScreen -> {
-                presenterOf { settingsPresenter.present() }
-            }
-
-            else -> null
         }
     }
 }

--- a/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/SettingsUi.kt
+++ b/shared/src/commonMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/SettingsUi.kt
@@ -37,10 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.slack.circuit.runtime.CircuitContext
-import com.slack.circuit.runtime.screen.Screen
-import com.slack.circuit.runtime.ui.Ui
-import com.slack.circuit.runtime.ui.ui
+import com.slack.circuit.codegen.annotations.CircuitInject
 import lightsaber.shared.generated.resources.Res
 import lightsaber.shared.generated.resources.settings_screen_about_group
 import lightsaber.shared.generated.resources.settings_screen_app_bar_back
@@ -48,12 +45,12 @@ import lightsaber.shared.generated.resources.settings_screen_app_bar_title
 import lightsaber.shared.generated.resources.settings_screen_lightsaber_blade_color
 import lightsaber.shared.generated.resources.settings_screen_lightsaber_group
 import lightsaber.shared.generated.resources.settings_screen_version
-import me.tatarka.inject.annotations.Inject
 import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import xyz.alaniz.aaron.lightsaber.ui.common.LightsaberTheme
 
-@OptIn(ExperimentalResourceApi::class)
+@CircuitInject(SettingsScreen::class, AppScope::class)
 @Composable
 fun Settings(settingsState: SettingsState, modifier: Modifier = Modifier) {
     LightsaberTheme {
@@ -202,21 +199,5 @@ private fun LightsaberCircle(color: Color, modifier: Modifier = Modifier) {
         border = BorderStroke(4.dp, color),
         modifier = modifier.size(32.dp).blur(4.dp).clip(CircleShape)
     ) {
-    }
-}
-
-@Inject
-class SettingsUiFactory : Ui.Factory {
-    override fun create(screen: Screen, context: CircuitContext): Ui<*>? {
-        return when (screen) {
-            is SettingsScreen -> ui<SettingsState> { state, modifier ->
-                Settings(
-                    state,
-                    modifier
-                )
-            }
-
-            else -> null
-        }
     }
 }

--- a/shared/src/iosArm64Main/kotlin/xyz/alaniz/aaron/lightsaber/di/IosArm64AppComponent.kt
+++ b/shared/src/iosArm64Main/kotlin/xyz/alaniz/aaron/lightsaber/di/IosArm64AppComponent.kt
@@ -7,11 +7,21 @@ import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
+/**
+ * TODO Remove this workaround when kotlin-anvil-inject 0.0.6 is released
+ */
 @Component
 @MergeComponent(AppScope::class)
 @SingleIn(AppScope::class)
-abstract class AndroidApplicationComponent(
+abstract class IosArm64AppComponent(
     @get:Provides protected val appScope: CoroutineScope,
-    @get:Provides protected val dataStorePath: DataStorePath,
-    @get:Provides protected val appContext: AppContext,
-) : AndroidApplicationComponentMerged
+    @get:Provides protected val dataStorePath: DataStorePath
+) : IosArm64AppComponentMerged
+
+actual fun createApplicationComponent(
+    appScope: CoroutineScope,
+    dataStorePath: DataStorePath
+): ApplicationComponent = IosArm64AppComponent::class.create(
+    appScope = appScope,
+    dataStorePath = dataStorePath
+)

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/audio/IosSoundPlayer.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/audio/IosSoundPlayer.kt
@@ -9,10 +9,15 @@ import platform.AVFAudio.AVAudioFile
 import platform.AVFAudio.AVAudioPCMBuffer
 import platform.AVFAudio.AVAudioPlayerNode
 import platform.AVFAudio.AVAudioPlayerNodeBufferOptions
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
 
 @Inject
 @OptIn(ExperimentalForeignApi::class)
+@ContributesBinding(AppScope::class)
+@SingleIn(AppScope::class)
 class IosSoundPlayer(private val audioEngine: AVAudioEngine) : SoundPlayer {
     private lateinit var soundResourceToPlayerNodeMap: MutableMap<SoundResource,
             Pair<AVAudioPCMBuffer, AVAudioPlayerNode>>

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosApplicationComponent.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosApplicationComponent.kt
@@ -1,34 +1,8 @@
 package xyz.alaniz.aaron.lightsaber.di
 
-import com.slack.circuit.runtime.Navigator
 import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.Component
-import me.tatarka.inject.annotations.KmpComponentCreate
-import me.tatarka.inject.annotations.Provides
-import xyz.alaniz.aaron.lightsaber.ui.settings.IosSettingsScreen
-import xyz.alaniz.aaron.lightsaber.ui.settings.SettingsScreen
 
-@Component
-abstract class IosApplicationComponent(
-    @get:Provides protected val navigator: Navigator,
-    @get:Provides protected val appScope: CoroutineScope,
-    dataStorePath: String,
-    @Component protected val iosSoundComponent: IosSoundComponent = IosSoundComponent.create(),
-    @Component protected val iosMotionComponent: IosMotionComponent = IosMotionComponent.create(),
-    @Component protected val dataStoreComponent: DatastoreComponent = DatastoreComponent.create(
-        appScope,
-        dataStorePath
-    )
-) : ApplicationComponent() {
-    protected val IosSettingsScreen.bind: SettingsScreen
-        @Provides get() = this
-
-    companion object
-}
-
-@KmpComponentCreate
-expect fun IosApplicationComponent.Companion.create(
-    navigator: Navigator,
+expect fun createApplicationComponent(
     appScope: CoroutineScope,
-    dataStorePath: String
-): IosApplicationComponent
+    dataStorePath: DataStorePath
+): ApplicationComponent

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosDatastoreComponent.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosDatastoreComponent.kt
@@ -1,8 +1,0 @@
-package xyz.alaniz.aaron.lightsaber.di
-
-import kotlinx.coroutines.CoroutineScope
-import me.tatarka.inject.annotations.KmpComponentCreate
-
-
-@KmpComponentCreate
-expect fun DatastoreComponent.Companion.create(scope: CoroutineScope, dataStorePath: String): DatastoreComponent

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosMotionComponent.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosMotionComponent.kt
@@ -1,30 +1,20 @@
 package xyz.alaniz.aaron.lightsaber.di
 
-import kotlinx.coroutines.flow.Flow
-import me.tatarka.inject.annotations.Component
-import me.tatarka.inject.annotations.KmpComponentCreate
 import me.tatarka.inject.annotations.Provides
-import xyz.alaniz.aaron.lightsaber.motion.IosSwingDetector
-import xyz.alaniz.aaron.lightsaber.motion.SwingEvent
 import platform.CoreMotion.CMMotionManager
 import platform.Foundation.NSOperationQueue
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import xyz.alaniz.aaron.lightsaber.motion.MotionQueue
 
-@Component
-abstract class IosMotionComponent {
-    private val motionManager: CMMotionManager = CMMotionManager()
+@ContributesTo(AppScope::class)
+interface IosMotionComponent {
+    @Provides
+    @SingleIn(AppScope::class)
+    fun providesMotionManager(): CMMotionManager = CMMotionManager()
 
     @Provides
-    internal fun providesMotionManager(): CMMotionManager = motionManager
-
-    @Provides
-    internal fun providesMotionQueue(): MotionQueue = MotionQueue(NSOperationQueue())
-
-    internal val IosSwingDetector.bind: Flow<SwingEvent>
-        @Provides get() = this.swings
-
-    companion object
+    @SingleIn(AppScope::class)
+    fun providesMotionQueue(): MotionQueue = MotionQueue(NSOperationQueue())
 }
-
-@KmpComponentCreate
-expect fun IosMotionComponent.Companion.create(): IosMotionComponent

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosSoundComponent.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/di/IosSoundComponent.kt
@@ -1,22 +1,15 @@
 package xyz.alaniz.aaron.lightsaber.di
 
-import xyz.alaniz.aaron.lightsaber.audio.IosSoundPlayer
-import xyz.alaniz.aaron.lightsaber.audio.SoundPlayer
-import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.KmpComponentCreate
 import me.tatarka.inject.annotations.Provides
 import platform.AVFAudio.AVAudioEngine
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesTo
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
-@Component
-abstract class IosSoundComponent {
-    internal val IosSoundPlayer.bind: SoundPlayer
-        @Provides get() = this
-
+@ContributesTo(AppScope::class)
+interface IosSoundComponent {
     @Provides
-    internal fun providesAvAudioEngine(): AVAudioEngine = AVAudioEngine()
-
-    companion object
+    @SingleIn(AppScope::class)
+    fun providesAvAudioEngine(): AVAudioEngine = AVAudioEngine()
 }
-
-@KmpComponentCreate
-expect fun IosSoundComponent.Companion.create(): IosSoundComponent

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/main.ios.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/main.ios.kt
@@ -6,14 +6,13 @@ import androidx.compose.ui.window.ComposeUIViewController
 import co.touchlab.kermit.DefaultFormatter
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.NSLogWriter
-import co.touchlab.kermit.OSLogWriter
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
-import xyz.alaniz.aaron.lightsaber.di.IosApplicationComponent
-import xyz.alaniz.aaron.lightsaber.di.create
+import xyz.alaniz.aaron.lightsaber.di.DataStorePath
+import xyz.alaniz.aaron.lightsaber.di.createApplicationComponent
 import xyz.alaniz.aaron.lightsaber.di.dataStoreFileName
 import xyz.alaniz.aaron.lightsaber.ui.lightsaber.IosLightsaberScreen
 import kotlin.experimental.ExperimentalNativeApi
@@ -55,11 +54,10 @@ fun MainViewController() = ComposeUIViewController(configure = {
     setUnhandledExceptionHook {
         Logger.e(throwable = it) { "Unhandled exception: cause = ${it.cause} message = ${it.message}" }
     }
-    App(initialScreen = IosLightsaberScreen) { scope, navigator ->
-        IosApplicationComponent.create(
-            navigator = navigator,
+    App(initialScreen = IosLightsaberScreen) { scope ->
+        createApplicationComponent(
             appScope = scope,
-            dataStorePath = dataStorePath
+            dataStorePath = DataStorePath(dataStorePath)
         )
     }
 }

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/motion/IosSwingDetector.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/motion/IosSwingDetector.kt
@@ -9,17 +9,22 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import me.tatarka.inject.annotations.Inject
 import platform.CoreMotion.CMMotionManager
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
+import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 import kotlin.math.abs
 
 private const val SWING_THRESHOLD = 2.5
 
 @OptIn(ExperimentalForeignApi::class)
 @Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class IosSwingDetector(
     private val motionManager: CMMotionManager,
     private val motionQueue: MotionQueue
-) {
-    val swings: Flow<SwingEvent> = callbackFlow {
+) : SwingDetector {
+    override val swings: Flow<SwingEvent> = callbackFlow {
         memScoped {
             motionManager.deviceMotionUpdateInterval = 0.1
 

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/lightsaber/IosLightsaberScreen.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/lightsaber/IosLightsaberScreen.kt
@@ -1,7 +1,9 @@
 package xyz.alaniz.aaron.lightsaber.ui.lightsaber
 
 import me.tatarka.inject.annotations.Inject
-import xyz.alaniz.aaron.lightsaber.ui.lightsaber.LightsaberScreen
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
 @Inject
+@ContributesBinding(AppScope::class)
 data object IosLightsaberScreen : LightsaberScreen

--- a/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/IosSettingsScreen.kt
+++ b/shared/src/iosMain/kotlin/xyz/alaniz/aaron/lightsaber/ui/settings/IosSettingsScreen.kt
@@ -1,6 +1,9 @@
 package xyz.alaniz.aaron.lightsaber.ui.settings
 
 import me.tatarka.inject.annotations.Inject
+import software.amazon.lastmile.kotlin.inject.anvil.AppScope
+import software.amazon.lastmile.kotlin.inject.anvil.ContributesBinding
 
 @Inject
+@ContributesBinding(AppScope::class)
 data object IosSettingsScreen : SettingsScreen

--- a/shared/src/iosSimulatorArm64Main/kotlin/xyz/alaniz/aaron/lightsaber/di/IosSimArm64AppComponent.kt
+++ b/shared/src/iosSimulatorArm64Main/kotlin/xyz/alaniz/aaron/lightsaber/di/IosSimArm64AppComponent.kt
@@ -7,11 +7,21 @@ import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
+/**
+ * TODO Remove this workaround when kotlin-anvil-inject 0.0.6 is released
+ */
 @Component
 @MergeComponent(AppScope::class)
 @SingleIn(AppScope::class)
-abstract class AndroidApplicationComponent(
+abstract class IosSimArm64AppComponent(
     @get:Provides protected val appScope: CoroutineScope,
-    @get:Provides protected val dataStorePath: DataStorePath,
-    @get:Provides protected val appContext: AppContext,
-) : AndroidApplicationComponentMerged
+    @get:Provides protected val dataStorePath: DataStorePath
+) : IosSimArm64AppComponentMerged
+
+actual fun createApplicationComponent(
+    appScope: CoroutineScope,
+    dataStorePath: DataStorePath
+): ApplicationComponent = IosSimArm64AppComponent::class.create(
+    appScope = appScope,
+    dataStorePath = dataStorePath
+)

--- a/shared/src/iosX64Main/kotlin/xyz/alaniz/aaron/lightsaber/di/IosX64AppComponent.kt
+++ b/shared/src/iosX64Main/kotlin/xyz/alaniz/aaron/lightsaber/di/IosX64AppComponent.kt
@@ -7,11 +7,21 @@ import software.amazon.lastmile.kotlin.inject.anvil.AppScope
 import software.amazon.lastmile.kotlin.inject.anvil.MergeComponent
 import software.amazon.lastmile.kotlin.inject.anvil.SingleIn
 
+/**
+ * TODO Remove this workaround when kotlin-anvil-inject 0.0.6 is released
+ */
 @Component
 @MergeComponent(AppScope::class)
 @SingleIn(AppScope::class)
-abstract class AndroidApplicationComponent(
+abstract class IosX64AppComponent(
     @get:Provides protected val appScope: CoroutineScope,
-    @get:Provides protected val dataStorePath: DataStorePath,
-    @get:Provides protected val appContext: AppContext,
-) : AndroidApplicationComponentMerged
+    @get:Provides protected val dataStorePath: DataStorePath
+) : IosX64AppComponentMerged
+
+actual fun createApplicationComponent(
+    appScope: CoroutineScope,
+    dataStorePath: DataStorePath
+): ApplicationComponent = IosX64AppComponent::class.create(
+    appScope = appScope,
+    dataStorePath = dataStorePath
+)


### PR DESCRIPTION
This change set updates the project to adopt Kotlin Inject. Mostly, this involved deleting boilerplate Circuit factory code, but also includes converting most of the components to interfaces and merging all contributions to AppScope in the platform application component.