### PR TITLE
ci: Update GitHub Actions to v4 and opt into Node.js 24

### DIFF
--- a/.github/actions/setup-lightsaber-ci/action.yml
+++ b/.github/actions/setup-lightsaber-ci/action.yml
@@ -4,48 +4,48 @@ runs:
   using: "composite"
   steps:
     - name: Setup JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: zulu
         cache: 'gradle'
     - name: Shared Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: build-shared-${{ github.sha }}
         path: |
           shared/build
 
     - name: Android App Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: build-android-${{ github.sha }}
         path: |
           androidApp/build
 
     - name: iOS App Debug iphoneos Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: build-ios-debug-iphoneos-${{ github.sha }}
         path: |
           iosApp/build/ios/Debug-iphoneos
 
     - name: iOS App Release iphoneos Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: build-ios-release-iphoneos-${{ github.sha }}
         path: |
           iosApp/build/ios/Release-iphoneos
 
     - name: iOS App Debug iphonesimulator Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: build-ios-debug-iphonesimulator-${{ github.sha }}
         path: |
           iosApp/build/ios/Debug-iphonesimulator
 
     - name: iOS App Release iphonesimulator Build Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: build-ios-release-iphonesimulator-${{ github.sha }}
         path: |

--- a/.github/workflows/lightsaber-ci.yml
+++ b/.github/workflows/lightsaber-ci.yml
@@ -11,11 +11,14 @@ concurrency:
   group: lightsaber-ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-shared:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
 
       - name: Build Shared
@@ -25,7 +28,7 @@ jobs:
     runs-on: macos-14
     needs: build-shared
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
 
       - name: Build Android App
@@ -39,7 +42,7 @@ jobs:
         target: [iphonesimulator, iphoneos]
     needs: build-shared
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
 
       # Signing Xcode applications
@@ -108,7 +111,7 @@ jobs:
     runs-on: macos-14
     needs: build-shared
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
 
       # Download native dependencies as a workaround for KT-74278.
@@ -122,7 +125,7 @@ jobs:
     runs-on: macos-14
     needs: build-shared
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
       - uses: futureware-tech/simulator-action@v4
         id: ios-simulator
@@ -144,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-shared
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
 
       - name: Enable KVM
@@ -164,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-androidApp
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
       - uses: ./.github/actions/setup-maestro
 
@@ -186,10 +189,10 @@ jobs:
     runs-on: macos-14
     needs: build-iosApp
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-lightsaber-ci
       - uses: ./.github/actions/setup-maestro
-      - uses: futureware-tech/simulator-action@v3
+      - uses: futureware-tech/simulator-action@v4
         id: ios-simulator
         with:
           model: 'iPhone 15'


### PR DESCRIPTION
This PR updates the GitHub Actions versions to v4 and opts into the Node.js 24 runtime to resolve deprecation warnings.