### PR TITLE
Refactor: Unified Lightsaber Gradle DSL for Plugin Capabilities

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -32,5 +32,9 @@ gradlePlugin {
             id = "lightsaber.kmp.circuit"
             implementationClass = "convention.KmpCircuitConventionPlugin"
         }
+        create("module") {
+            id = "lightsaber.module"
+            implementationClass = "convention.LightsaberModuleConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/convention/KmpLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/convention/KmpLibraryConventionPlugin.kt
@@ -16,8 +16,6 @@ class KmpLibraryConventionPlugin : Plugin<Project> {
                 apply("com.android.library")
                 apply("com.google.devtools.ksp")
                 apply("dev.zacsweers.metro")
-                apply("org.jetbrains.kotlin.plugin.parcelize")
-                apply("org.jetbrains.kotlin.plugin.parcelize")
             }
             extensions.configure<KotlinMultiplatformExtension> {
                 androidTarget {

--- a/build-logic/convention/src/main/kotlin/convention/LightsaberModuleConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/convention/LightsaberModuleConventionPlugin.kt
@@ -1,0 +1,15 @@
+package convention
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class LightsaberModuleConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            extensions.create("lightsaber", LightsaberModuleExtension::class.java, this)
+
+            // Base KMP library convention is always applied
+            pluginManager.apply("lightsaber.kmp.library")
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/convention/LightsaberModuleExtension.kt
+++ b/build-logic/convention/src/main/kotlin/convention/LightsaberModuleExtension.kt
@@ -1,0 +1,22 @@
+package convention
+
+import org.gradle.api.Project
+import javax.inject.Inject
+
+open class LightsaberModuleExtension @Inject constructor(private val project: Project) {
+    var compose: Boolean = false
+        set(value) {
+            field = value
+            if (value) project.pluginManager.apply("lightsaber.kmp.compose")
+        }
+    var circuit: Boolean = false
+        set(value) {
+            field = value
+            if (value) project.pluginManager.apply("lightsaber.kmp.circuit")
+        }
+    var parcelize: Boolean = false
+        set(value) {
+            field = value
+            if (value) project.pluginManager.apply("org.jetbrains.kotlin.plugin.parcelize")
+        }
+}

--- a/build-logic/convention/src/main/kotlin/convention/LightsaberModuleExtension.kt
+++ b/build-logic/convention/src/main/kotlin/convention/LightsaberModuleExtension.kt
@@ -1,6 +1,8 @@
 package convention
 
 import org.gradle.api.Project
+import org.jetbrains.compose.ComposeExtension
+import org.jetbrains.compose.resources.ResourcesExtension
 import javax.inject.Inject
 
 open class LightsaberModuleExtension @Inject constructor(private val project: Project) {
@@ -18,5 +20,19 @@ open class LightsaberModuleExtension @Inject constructor(private val project: Pr
         set(value) {
             field = value
             if (value) project.pluginManager.apply("org.jetbrains.kotlin.plugin.parcelize")
+        }
+    var packageOfResClass: String? = null
+        set(value) {
+            field = value
+            if (value != null) {
+                // Ensure compose is applied first
+                if (!compose) {
+                    compose = true
+                }
+                val composeExt = project.extensions.getByType(ComposeExtension::class.java)
+                val resourcesExt = composeExt.extensions.getByType(ResourcesExtension::class.java)
+                resourcesExt.publicResClass = true
+                resourcesExt.packageOfResClass = value
+            }
         }
 }

--- a/build-logic/convention/src/main/kotlin/convention/LightsaberModuleExtension.kt
+++ b/build-logic/convention/src/main/kotlin/convention/LightsaberModuleExtension.kt
@@ -21,18 +21,13 @@ open class LightsaberModuleExtension @Inject constructor(private val project: Pr
             field = value
             if (value) project.pluginManager.apply("org.jetbrains.kotlin.plugin.parcelize")
         }
-    var packageOfResClass: String? = null
-        set(value) {
-            field = value
-            if (value != null) {
-                // Ensure compose is applied first
-                if (!compose) {
-                    compose = true
-                }
-                val composeExt = project.extensions.getByType(ComposeExtension::class.java)
-                val resourcesExt = composeExt.extensions.getByType(ResourcesExtension::class.java)
-                resourcesExt.publicResClass = true
-                resourcesExt.packageOfResClass = value
-            }
+
+    fun resources(action: org.gradle.api.Action<ResourcesExtension>) {
+        if (!compose) {
+            compose = true
         }
+        val composeExt = project.extensions.getByType(ComposeExtension::class.java)
+        val resourcesExt = composeExt.extensions.getByType(ResourcesExtension::class.java)
+        action.execute(resourcesExt)
+    }
 }

--- a/core/audio/build.gradle.kts
+++ b/core/audio/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 lightsaber {
     circuit = true
+    compose = true
 }
 android {
     namespace = "xyz.alaniz.aaron.lightsaber.core.audio"

--- a/core/audio/build.gradle.kts
+++ b/core/audio/build.gradle.kts
@@ -4,13 +4,10 @@ plugins {
 lightsaber {
     circuit = true
     compose = true
+    packageOfResClass = "xyz.alaniz.aaron.lightsaber.core.audio.resources"
 }
 android {
     namespace = "xyz.alaniz.aaron.lightsaber.core.audio"
-}
-compose.resources {
-    publicResClass = true
-    packageOfResClass = "xyz.alaniz.aaron.lightsaber.core.audio.resources"
 }
 kotlin {
     sourceSets {

--- a/core/audio/build.gradle.kts
+++ b/core/audio/build.gradle.kts
@@ -3,8 +3,10 @@ plugins {
 }
 lightsaber {
     circuit = true
-    compose = true
-    packageOfResClass = "xyz.alaniz.aaron.lightsaber.core.audio.resources"
+    resources {
+        publicResClass = true
+        packageOfResClass = "xyz.alaniz.aaron.lightsaber.core.audio.resources"
+    }
 }
 android {
     namespace = "xyz.alaniz.aaron.lightsaber.core.audio"

--- a/core/audio/build.gradle.kts
+++ b/core/audio/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
-    id("lightsaber.kmp.library")
-    id("lightsaber.kmp.circuit")
+    id("lightsaber.module")
+}
+lightsaber {
+    circuit = true
 }
 android {
     namespace = "xyz.alaniz.aaron.lightsaber.core.audio"

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
-    id("lightsaber.kmp.library")
-    id("lightsaber.kmp.circuit")
+    id("lightsaber.module")
+}
+lightsaber {
+    circuit = true
 }
 android { namespace = "xyz.alaniz.aaron.lightsaber.core.data" }
 kotlin {

--- a/core/motion/build.gradle.kts
+++ b/core/motion/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
-    id("lightsaber.kmp.library")
-    id("lightsaber.kmp.circuit")
+    id("lightsaber.module")
+}
+lightsaber {
+    circuit = true
 }
 android { namespace = "xyz.alaniz.aaron.lightsaber.core.motion" }
 kotlin {

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,7 +1,9 @@
 plugins {
-    id("lightsaber.kmp.library")
-    id("lightsaber.kmp.compose")
-    id("lightsaber.kmp.circuit")
+    id("lightsaber.module")
+}
+lightsaber {
+    compose = true
+    circuit = true
 }
 android { namespace = "xyz.alaniz.aaron.lightsaber.core.ui" }
 kotlin {

--- a/feature/lightsaber/build.gradle.kts
+++ b/feature/lightsaber/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
-    id("lightsaber.kmp.library")
-    id("lightsaber.kmp.compose")
-    id("lightsaber.kmp.circuit")
-    id("org.jetbrains.kotlin.plugin.parcelize")
+    id("lightsaber.module")
+}
+lightsaber {
+    compose = true
+    circuit = true
+    parcelize = true
 }
 android { namespace = "xyz.alaniz.aaron.lightsaber.feature.lightsaber" }
 kotlin {

--- a/feature/settings/build.gradle.kts
+++ b/feature/settings/build.gradle.kts
@@ -1,8 +1,10 @@
 plugins {
-    id("lightsaber.kmp.library")
-    id("lightsaber.kmp.compose")
-    id("lightsaber.kmp.circuit")
-    id("org.jetbrains.kotlin.plugin.parcelize")
+    id("lightsaber.module")
+}
+lightsaber {
+    compose = true
+    circuit = true
+    parcelize = true
 }
 android { namespace = "xyz.alaniz.aaron.lightsaber.feature.settings" }
 kotlin {

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -2,11 +2,13 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
-    id("lightsaber.kmp.library")
-    id("lightsaber.kmp.compose")
-    id("lightsaber.kmp.circuit")
+    id("lightsaber.module")
     alias(libs.plugins.kotlin.native.cocoapods)
     alias(libs.plugins.burst)
+}
+lightsaber {
+    compose = true
+    circuit = true
 }
 
 kotlin {


### PR DESCRIPTION
This PR refactors the build logic convention plugins to use a single unified `lightsaber.module` DSL instead of manually applying multiple convention capabilities in each feature module.

### Changes
- Introduced `LightsaberModuleExtension` to configure sub-plugin activation (`compose`, `circuit`, `parcelize`).
- Created `LightsaberModuleConventionPlugin` to register the extension and unconditionally apply the KMP base configuration.
- Removed redundant `org.jetbrains.kotlin.plugin.parcelize` applications from `KmpLibraryConventionPlugin.kt`.
- Refactored all internal core and feature `build.gradle.kts` scripts to configure capabilities via the newly introduced `lightsaber { ... }` block.